### PR TITLE
Fix GL leak when rendering footprints

### DIFF
--- a/src/main/java/org/fentanylsolutions/anextratouch/footsteps/FootprintManager.java
+++ b/src/main/java/org/fentanylsolutions/anextratouch/footsteps/FootprintManager.java
@@ -171,6 +171,7 @@ public class FootprintManager {
         GL11.glEnable(GL11.GL_BLEND);
         GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
         GL11.glDepthMask(false);
+        GL11.glPushAttrib(GL11.GL_LIGHTING_BIT);
         GL11.glDisable(GL11.GL_LIGHTING);
 
         Tessellator tess = Tessellator.instance;
@@ -207,7 +208,7 @@ public class FootprintManager {
 
         tess.draw();
 
-        GL11.glEnable(GL11.GL_LIGHTING);
+        GL11.glPopAttrib();
         GL11.glDepthMask(true);
         GL11.glDisable(GL11.GL_BLEND);
     }


### PR DESCRIPTION

Title, when rendering footprints in third-person / with some other mods, there was a `GL_LIGHTING` leak


<details>

<summary>Reason & Fix</summary>


Because footprints rendering code assumed `GL_LIGHTING` was enabled by default, which **may** not be the case on `RenderWorldLastEvent`

Therefore, we use glPushAttrib and don't care whether it was enabled or not

</details>


Here's what it looked like:


https://github.com/user-attachments/assets/3589176f-04e3-45c5-8cde-6883e68a027c

