### PR TITLE
Proper late mixins loading + compatibility with Hbm's NTM explosions

### DIFF
--- a/src/main/java/org/fentanylsolutions/anextratouch/Config.java
+++ b/src/main/java/org/fentanylsolutions/anextratouch/Config.java
@@ -131,6 +131,7 @@ public class Config {
     public static float cameraShakeMaxIntensity = 2.5f;
     public static float cameraShakeMaxFrequency = 6.0f;
     public static float cameraExplosionTrauma = 1.0f;
+    public static float cameraExplosionLength = 2.0f;
     public static float cameraThunderTrauma = 0.05f;
     public static float cameraHandSwingTrauma = 0.03f;
     public static boolean cameraFallShakeEnabled = true;
@@ -704,6 +705,13 @@ public class Config {
                 0.0f,
                 1.0f,
                 "Trauma intensity for explosion screen shakes.");
+            cameraExplosionLength = config.getFloat(
+                "cameraExplosionLength",
+                Categories.camera,
+                cameraExplosionLength,
+                0.0f,
+                100.0f,
+                "Duration in seconds for explosion screen shakes.");
             cameraThunderTrauma = config.getFloat(
                 "cameraThunderTrauma",
                 Categories.camera,

--- a/src/main/java/org/fentanylsolutions/anextratouch/core/EarlyMixinLoader.java
+++ b/src/main/java/org/fentanylsolutions/anextratouch/core/EarlyMixinLoader.java
@@ -1,50 +1,15 @@
 package org.fentanylsolutions.anextratouch.core;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
 import org.fentanylsolutions.anextratouch.AnExtraTouch;
 
-import cpw.mods.fml.relauncher.FMLLaunchHandler;
 import cpw.mods.fml.relauncher.IFMLLoadingPlugin;
 
 @SuppressWarnings("unused")
 @IFMLLoadingPlugin.MCVersion("1.7.10")
 public class EarlyMixinLoader extends FentEarlyMixinLoader {
-
-    public enum Side {
-        CLIENT,
-        SERVER,
-        BOTH
-    }
-
-    public static boolean isServer() {
-        return FMLLaunchHandler.side()
-            .isServer();
-    }
-
-    public static class MixinBuilder {
-
-        private final List<String> mixins = new ArrayList<>();
-
-        public MixinBuilder addMixin(String name, Side side, String modid) {
-            if ((side == Side.CLIENT && isServer()) || (side == Side.SERVER && !isServer())) {
-                return this;
-            }
-
-            mixins.add(modid + "." + name);
-            return this;
-        }
-
-        public MixinBuilder addMixin(String name, Side side) {
-            return addMixin(name, side, "minecraft");
-        }
-
-        public List<String> build() {
-            return mixins;
-        }
-    }
 
     @Override
     public String getMixinConfig() {
@@ -57,12 +22,12 @@ public class EarlyMixinLoader extends FentEarlyMixinLoader {
             // Accessors
 
             // Rest
-            .addMixin("MixinEntity", Side.BOTH)
-            .addMixin("MixinGuiScreen", Side.CLIENT)
-            .addMixin("MixinEntityRenderer", Side.CLIENT)
-            .addMixin("MixinExplosion", Side.CLIENT)
-            .addMixin("MixinEntityLightningBolt", Side.CLIENT)
-            .addMixin("MixinEntityLivingBase", Side.CLIENT)
+            .addMixin("MixinEntity", MixinBuilder.Side.BOTH)
+            .addMixin("MixinGuiScreen", MixinBuilder.Side.CLIENT)
+            .addMixin("MixinEntityRenderer", MixinBuilder.Side.CLIENT)
+            .addMixin("MixinExplosion", MixinBuilder.Side.CLIENT)
+            .addMixin("MixinEntityLightningBolt", MixinBuilder.Side.CLIENT)
+            .addMixin("MixinEntityLivingBase", MixinBuilder.Side.CLIENT)
             .build();
     }
 }

--- a/src/main/java/org/fentanylsolutions/anextratouch/core/LateMixinLoader.java
+++ b/src/main/java/org/fentanylsolutions/anextratouch/core/LateMixinLoader.java
@@ -19,10 +19,12 @@ public class LateMixinLoader implements ILateMixinLoader {
     }
 
     @Override
-    public List<String> getMixins(Set<String> loadedCoreMods) {
-        return new EarlyMixinLoader.MixinBuilder()
-            .addMixin("MixinDSFootsteps", EarlyMixinLoader.Side.CLIENT, "dsurround")
-            .addMixin("MixinBlizzSnowTrail", EarlyMixinLoader.Side.BOTH, "ThermalFoundation")
+    public List<String> getMixins(Set<String> loadedMods) {
+        return new MixinBuilder().addMixin("MixinDSFootsteps", MixinBuilder.Side.CLIENT, "dsurround")
+            .addMixin("MixinBlizzSnowTrail", MixinBuilder.Side.BOTH, "ThermalFoundation")
+            .addMixin("MixinExplosionNT", MixinBuilder.Side.BOTH, "hbm")
+            .addMixin("MixinExplosionVNT", MixinBuilder.Side.BOTH, "hbm")
+            .addMixin("MixinRenderTorex", MixinBuilder.Side.CLIENT, "hbm")
             .build();
     }
 }

--- a/src/main/java/org/fentanylsolutions/anextratouch/core/MixinBuilder.java
+++ b/src/main/java/org/fentanylsolutions/anextratouch/core/MixinBuilder.java
@@ -1,0 +1,44 @@
+package org.fentanylsolutions.anextratouch.core;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.relauncher.FMLLaunchHandler;
+
+public class MixinBuilder {
+
+    public enum Side {
+        CLIENT,
+        SERVER,
+        BOTH
+    }
+
+    public static boolean isServer() {
+        return FMLLaunchHandler.side()
+            .isServer();
+    }
+
+    private final List<String> mixins = new ArrayList<>();
+
+    public MixinBuilder addMixin(String name, Side side, String modid) {
+        if ((side == Side.CLIENT && isServer()) || (side == Side.SERVER && !isServer())) {
+            return this;
+        }
+        if (!modid.equals("minecraft") && !Loader.isModLoaded(modid)) {
+            return this;
+        }
+
+        mixins.add(modid + "." + name);
+        return this;
+    }
+
+    public MixinBuilder addMixin(String name, Side side) {
+        return addMixin(name, side, "minecraft");
+    }
+
+    public List<String> build() {
+        return mixins;
+    }
+
+}

--- a/src/main/java/org/fentanylsolutions/anextratouch/mixins/early/minecraft/MixinExplosion.java
+++ b/src/main/java/org/fentanylsolutions/anextratouch/mixins/early/minecraft/MixinExplosion.java
@@ -38,6 +38,6 @@ public abstract class MixinExplosion {
         shake.position.set(explosionX, explosionY, explosionZ);
         shake.radius = explosionSize * 10f;
         shake.trauma = Config.cameraExplosionTrauma;
-        shake.lengthInSeconds = 2f;
+        shake.lengthInSeconds = Config.cameraExplosionLength;
     }
 }

--- a/src/main/java/org/fentanylsolutions/anextratouch/mixins/late/hbm/MixinExplosionNT.java
+++ b/src/main/java/org/fentanylsolutions/anextratouch/mixins/late/hbm/MixinExplosionNT.java
@@ -1,0 +1,44 @@
+package org.fentanylsolutions.anextratouch.mixins.late.hbm;
+
+import net.minecraft.world.Explosion;
+import net.minecraft.world.World;
+
+import org.fentanylsolutions.anextratouch.network.NetworkHandler;
+import org.fentanylsolutions.anextratouch.network.message.MessageExplosionShake;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import cpw.mods.fml.common.network.NetworkRegistry;
+
+@Pseudo
+@Mixin(targets = "com.hbm.explosion.ExplosionNT", remap = false)
+public abstract class MixinExplosionNT {
+
+    @Shadow
+    private World worldObj;
+
+    @Inject(method = "func_77279_a", at = @At("RETURN"))
+    private void anextratouch$onExplosion(CallbackInfo ci) {
+        if (worldObj.isRemote) return;
+
+        Explosion explosion = (Explosion) (Object) this;
+
+        double posX = explosion.explosionX;
+        double posY = explosion.explosionY;
+        double posZ = explosion.explosionZ;
+
+        NetworkHandler.channel.sendToAllAround(
+            new MessageExplosionShake(posX, posY, posZ, explosion.explosionSize),
+            new NetworkRegistry.TargetPoint(
+                worldObj.provider.dimensionId,
+                posX,
+                posY,
+                posZ,
+                explosion.explosionSize * 10f));
+    }
+
+}

--- a/src/main/java/org/fentanylsolutions/anextratouch/mixins/late/hbm/MixinExplosionVNT.java
+++ b/src/main/java/org/fentanylsolutions/anextratouch/mixins/late/hbm/MixinExplosionVNT.java
@@ -1,0 +1,40 @@
+package org.fentanylsolutions.anextratouch.mixins.late.hbm;
+
+import net.minecraft.world.World;
+
+import org.fentanylsolutions.anextratouch.network.NetworkHandler;
+import org.fentanylsolutions.anextratouch.network.message.MessageExplosionShake;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import cpw.mods.fml.common.network.NetworkRegistry;
+
+@Pseudo
+@Mixin(targets = "com.hbm.explosion.vanillant.ExplosionVNT", remap = false)
+public abstract class MixinExplosionVNT {
+
+    @Shadow
+    public World world;
+    @Shadow
+    public double posX;
+    @Shadow
+    public double posY;
+    @Shadow
+    public double posZ;
+    @Shadow
+    public float size;
+
+    @Inject(method = "explode", at = @At("RETURN"))
+    private void anextratouch$explode(CallbackInfo ci) {
+        if (world.isRemote) return;
+
+        NetworkHandler.channel.sendToAllAround(
+            new MessageExplosionShake(posX, posY, posZ, size),
+            new NetworkRegistry.TargetPoint(world.provider.dimensionId, posX, posY, posZ, size * 10f));
+    }
+
+}

--- a/src/main/java/org/fentanylsolutions/anextratouch/mixins/late/hbm/MixinRenderTorex.java
+++ b/src/main/java/org/fentanylsolutions/anextratouch/mixins/late/hbm/MixinRenderTorex.java
@@ -1,0 +1,33 @@
+package org.fentanylsolutions.anextratouch.mixins.late.hbm;
+
+import net.minecraft.entity.Entity;
+
+import org.fentanylsolutions.anextratouch.Config;
+import org.fentanylsolutions.anextratouch.handlers.client.camera.ScreenShakeManager;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Pseudo
+@Mixin(targets = "com.hbm.render.entity.effect.RenderTorex", remap = false)
+public class MixinRenderTorex {
+
+    @Inject(
+        method = "func_76986_a",
+        at = @At(value = "INVOKE", target = "Lcom/hbm/main/ServerProxy;me()Lnet/minecraft/entity/player/EntityPlayer;"))
+    private void anextratouch$doRender(Entity entity, double x, double y, double z, float f0, float interp,
+        CallbackInfo ci) {
+        if (!Config.cameraOverhaulEnabled) {
+            return;
+        }
+
+        ScreenShakeManager.Slot shake = ScreenShakeManager.createDirect();
+        shake.position.set(entity.posX, entity.posY, entity.posZ);
+        shake.radius = 1000f;
+        shake.trauma = Config.cameraExplosionTrauma;
+        shake.lengthInSeconds = Config.cameraExplosionLength;
+    }
+
+}

--- a/src/main/java/org/fentanylsolutions/anextratouch/network/NetworkHandler.java
+++ b/src/main/java/org/fentanylsolutions/anextratouch/network/NetworkHandler.java
@@ -2,8 +2,10 @@ package org.fentanylsolutions.anextratouch.network;
 
 import org.fentanylsolutions.anextratouch.AnExtraTouch;
 import org.fentanylsolutions.anextratouch.network.handler.HandlerArmorStep;
+import org.fentanylsolutions.anextratouch.network.handler.HandlerExplosionShake;
 import org.fentanylsolutions.anextratouch.network.handler.HandlerHello;
 import org.fentanylsolutions.anextratouch.network.message.MessageArmorStep;
+import org.fentanylsolutions.anextratouch.network.message.MessageExplosionShake;
 import org.fentanylsolutions.anextratouch.network.message.MessageHello;
 
 import cpw.mods.fml.common.network.NetworkRegistry;
@@ -18,5 +20,6 @@ public class NetworkHandler {
     public static void init() {
         channel.registerMessage(HandlerHello.class, MessageHello.class, discriminator++, Side.CLIENT);
         channel.registerMessage(HandlerArmorStep.class, MessageArmorStep.class, discriminator++, Side.CLIENT);
+        channel.registerMessage(HandlerExplosionShake.class, MessageExplosionShake.class, discriminator++, Side.CLIENT);
     }
 }

--- a/src/main/java/org/fentanylsolutions/anextratouch/network/handler/HandlerExplosionShake.java
+++ b/src/main/java/org/fentanylsolutions/anextratouch/network/handler/HandlerExplosionShake.java
@@ -1,0 +1,30 @@
+package org.fentanylsolutions.anextratouch.network.handler;
+
+import org.fentanylsolutions.anextratouch.Config;
+import org.fentanylsolutions.anextratouch.handlers.client.camera.ScreenShakeManager;
+import org.fentanylsolutions.anextratouch.network.message.MessageExplosionShake;
+
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+public class HandlerExplosionShake implements IMessageHandler<MessageExplosionShake, IMessage> {
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public IMessage onMessage(final MessageExplosionShake message, MessageContext ctx) {
+
+        if (Config.cameraOverhaulEnabled) {
+            ScreenShakeManager.Slot shake = ScreenShakeManager.createDirect();
+            shake.position.set(message.posX, message.posY, message.posZ);
+            shake.radius = message.size * 10f;
+            shake.trauma = Config.cameraExplosionTrauma;
+            shake.lengthInSeconds = Config.cameraExplosionLength;
+        }
+
+        return null;
+    }
+
+}

--- a/src/main/java/org/fentanylsolutions/anextratouch/network/message/MessageExplosionShake.java
+++ b/src/main/java/org/fentanylsolutions/anextratouch/network/message/MessageExplosionShake.java
@@ -1,0 +1,38 @@
+package org.fentanylsolutions.anextratouch.network.message;
+
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import io.netty.buffer.ByteBuf;
+
+public class MessageExplosionShake implements IMessage {
+
+    public double posX, posY, posZ;
+    public float size;
+
+    public MessageExplosionShake() {}
+
+    public MessageExplosionShake(double posX, double posY, double posZ, float size) {
+        this.posX = posX;
+        this.posY = posY;
+        this.posZ = posZ;
+
+        this.size = size;
+    }
+
+    @Override
+    public void fromBytes(ByteBuf buf) {
+        this.posX = buf.readDouble();
+        this.posY = buf.readDouble();
+        this.posZ = buf.readDouble();
+
+        this.size = buf.readFloat();
+    }
+
+    @Override
+    public void toBytes(ByteBuf buf) {
+        buf.writeDouble(posX);
+        buf.writeDouble(posY);
+        buf.writeDouble(posZ);
+
+        buf.writeFloat(size);
+    }
+}


### PR DESCRIPTION
* MixinBuilder has been moved from EarlyMixinLoader and is now shared
* Now it checks whether the mod is loaded before adding a mixin. Fixes invalid mixin log spam and crashes with `-Dmixin.debug.X`
* Added camera shake compatibility with Hbm's NTM explosions
	- Note: due to *some* NTM explosions are entirely server-side, just `ScreenShakeManager.createDirect()` won't work. Therefore, a new `ExplosionShake` packet was added. It allows for syncing explosion data from server to client
	- Thus, requires AET to be installed on the server side
* Added `cameraExplosionLength` config option - adjusts the duration of shaking from the explosion
	
Tested and confirmed to work in singleplayer and on server:


https://github.com/user-attachments/assets/f8ae5bde-9722-4395-a728-4c576f0a3f5e


https://github.com/user-attachments/assets/02a3444d-e6c1-451e-83c9-2c2e20bbd452

