### PR TITLE
Fix Bugtorch mixin crash

### DIFF
--- a/src/main/java/org/fentanylsolutions/anextratouch/mixins/early/minecraft/MixinMinecraftServer.java
+++ b/src/main/java/org/fentanylsolutions/anextratouch/mixins/early/minecraft/MixinMinecraftServer.java
@@ -10,14 +10,16 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import com.llamalad7.mixinextras.sugar.Local;
 
-@Mixin(MinecraftServer.class)
+@Mixin(value = MinecraftServer.class, priority = 1100)
 public class MixinMinecraftServer {
 
     @Inject(
         method = "initialWorldChunkLoad",
         at = @At(
             value = "INVOKE",
-            target = "Lnet/minecraft/world/gen/ChunkProviderServer;loadChunk(II)Lnet/minecraft/world/chunk/Chunk;"))
+            target = "Lnet/minecraft/world/gen/ChunkProviderServer;loadChunk(II)Lnet/minecraft/world/chunk/Chunk;"),
+        require = 0,
+        expect = 0)
     private void initialWorldChunkLoad(CallbackInfo ci, @Local(ordinal = 0) int progress) {
         AnExtraTouch.vic.chunkLoadingProgress = (progress * 100 / 625);
     }


### PR DESCRIPTION
Fixed a conflict between AET and BugTorch mixins for `MinecraftServer::func_71222_d()V`

Fixes #6